### PR TITLE
Optimizar rendimiento landing: logo ligero, imágenes de workout y AppCheck diferido

### DIFF
--- a/src/branding/logoConfig.ts
+++ b/src/branding/logoConfig.ts
@@ -16,7 +16,7 @@ export const mainLogo: LogoAsset = {
 };
 
 export const iconLogo: LogoAsset = {
-  src: "/pwa-192x192.png",
+  src: "/favicon.svg",
   alt: "FITTWIZ icon",
 };
 

--- a/src/components/landing/sections/SocialShareSection.tsx
+++ b/src/components/landing/sections/SocialShareSection.tsx
@@ -1,7 +1,21 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Share2, CheckCircle2 } from "lucide-react";
 
 export const SocialShareSection: React.FC = () => {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(max-width: 768px)");
+    const updateLayout = (event?: MediaQueryListEvent) => {
+      setIsMobile(event?.matches ?? mediaQuery.matches);
+    };
+
+    updateLayout();
+    mediaQuery.addEventListener("change", updateLayout);
+
+    return () => mediaQuery.removeEventListener("change", updateLayout);
+  }, []);
+
   return (
     <section
       className='mb-24 grid lg:grid-cols-2 gap-16 lg:gap-10 items-center'
@@ -12,41 +26,47 @@ export const SocialShareSection: React.FC = () => {
           {/* Background glow */}
           <div className='absolute inset-0 bg-accent-500/20 blur-3xl rounded-full scale-150 group-hover:bg-primary-500/30 transition-colors duration-700' />
 
-          {/* Card 1 (Left) */}
-          <div
-            className='absolute inset-0 origin-bottom-left transition-all duration-500 ease-[cubic-bezier(0.16,1,0.3,1)] shadow-lg rounded-2xl overflow-hidden border border-slate-200/50 dark:border-surface-800/50 bg-white dark:bg-surface-900 
-            -rotate-12 -translate-x-6 scale-95 opacity-80
-            group-hover:-rotate-24 group-hover:-translate-x-24 group-hover:-translate-y-4 group-hover:scale-100 group-hover:opacity-100 group-hover:shadow-2xl group-hover:z-20'
-          >
-            <img
-              src='/assets/images/fittwiz-workout-2.webp'
-              alt='Previsualización de rutina en estilo tarjeta oscura'
-              width={300}
-              height={400}
-              loading='lazy'
-              decoding='async'
-              className='w-full h-full object-cover select-none pointer-events-none'
-            />
-            <div className='absolute inset-0 bg-linear-to-t from-slate-900/60 to-transparent' />
-          </div>
+          {!isMobile && (
+            <>
+              {/* Card 1 (Left) */}
+              <div
+                className='absolute inset-0 origin-bottom-left transition-all duration-500 ease-[cubic-bezier(0.16,1,0.3,1)] shadow-lg rounded-2xl overflow-hidden border border-slate-200/50 dark:border-surface-800/50 bg-white dark:bg-surface-900 
+                -rotate-12 -translate-x-6 scale-95 opacity-80
+                group-hover:-rotate-24 group-hover:-translate-x-24 group-hover:-translate-y-4 group-hover:scale-100 group-hover:opacity-100 group-hover:shadow-2xl group-hover:z-20'
+              >
+                <img
+                  src='/assets/images/fittwiz-workout-2.webp'
+                  alt='Previsualización de rutina en estilo tarjeta oscura'
+                  width={300}
+                  height={400}
+                  loading='lazy'
+                  decoding='async'
+                  fetchPriority='low'
+                  className='w-full h-full object-cover select-none pointer-events-none'
+                />
+                <div className='absolute inset-0 bg-linear-to-t from-slate-900/60 to-transparent' />
+              </div>
 
-          {/* Card 2 (Right) */}
-          <div
-            className='absolute inset-0 origin-bottom-right transition-all duration-500 ease-[cubic-bezier(0.16,1,0.3,1)] shadow-lg rounded-2xl overflow-hidden border border-slate-200/50 dark:border-surface-800/50 bg-white dark:bg-surface-900 
-            rotate-12 translate-x-6 scale-95 opacity-80
-            group-hover:rotate-24 group-hover:translate-x-24 group-hover:-translate-y-4 group-hover:scale-100 group-hover:opacity-100 group-hover:shadow-2xl group-hover:z-20'
-          >
-            <img
-              src='/assets/images/fittwiz-workout-3.webp'
-              alt='Previsualización de rutina en estilo tarjeta clara y minimalista'
-              width={300}
-              height={400}
-              loading='lazy'
-              decoding='async'
-              className='w-full h-full object-cover select-none pointer-events-none'
-            />
-            <div className='absolute inset-0 bg-linear-to-t from-slate-900/60 to-transparent' />
-          </div>
+              {/* Card 2 (Right) */}
+              <div
+                className='absolute inset-0 origin-bottom-right transition-all duration-500 ease-[cubic-bezier(0.16,1,0.3,1)] shadow-lg rounded-2xl overflow-hidden border border-slate-200/50 dark:border-surface-800/50 bg-white dark:bg-surface-900 
+                rotate-12 translate-x-6 scale-95 opacity-80
+                group-hover:rotate-24 group-hover:translate-x-24 group-hover:-translate-y-4 group-hover:scale-100 group-hover:opacity-100 group-hover:shadow-2xl group-hover:z-20'
+              >
+                <img
+                  src='/assets/images/fittwiz-workout-3.webp'
+                  alt='Previsualización de rutina en estilo tarjeta clara y minimalista'
+                  width={300}
+                  height={400}
+                  loading='lazy'
+                  decoding='async'
+                  fetchPriority='low'
+                  className='w-full h-full object-cover select-none pointer-events-none'
+                />
+                <div className='absolute inset-0 bg-linear-to-t from-slate-900/60 to-transparent' />
+              </div>
+            </>
+          )}
 
           {/* Card 3 (Center) */}
           <div
@@ -61,6 +81,7 @@ export const SocialShareSection: React.FC = () => {
               height={400}
               loading='lazy'
               decoding='async'
+              fetchPriority='low'
               className='w-full h-full object-cover select-none pointer-events-none'
             />
             <div className='absolute inset-0 bg-linear-to-t from-slate-900/40 to-transparent' />

--- a/src/hooks/useLazyAuth.ts
+++ b/src/hooks/useLazyAuth.ts
@@ -52,9 +52,6 @@ export const useLazyAuth = (): UseLazyAuthReturn => {
         import("posthog-js").catch(() => null),
       ]);
 
-      const { initAppCheck } = await import("../config/firebase");
-      void initAppCheck();
-
       if (!auth) {
         if (mountedRef.current) setLoading(false);
         return;
@@ -118,11 +115,12 @@ export const useLazyAuth = (): UseLazyAuthReturn => {
 
   const loginWithGoogle = useCallback(async () => {
     await initFirebase();
-    const [{ auth }, { signInWithPopup, linkWithPopup, GoogleAuthProvider }] = await Promise.all([
+    const [{ auth, initAppCheck }, { signInWithPopup, linkWithPopup, GoogleAuthProvider }] = await Promise.all([
       import("../config/firebase"),
       import("firebase/auth"),
     ]);
     if (!auth) throw new Error("Firebase no configurado");
+    await initAppCheck();
     const provider = new GoogleAuthProvider();
     if (auth.currentUser?.isAnonymous) {
       await linkWithPopup(auth.currentUser, provider);
@@ -134,9 +132,10 @@ export const useLazyAuth = (): UseLazyAuthReturn => {
   const loginWithEmail = useCallback(
     async (email: string, password: string) => {
       await initFirebase();
-      const [{ auth }, { signInWithEmailAndPassword, linkWithCredential, EmailAuthProvider }] =
+      const [{ auth, initAppCheck }, { signInWithEmailAndPassword, linkWithCredential, EmailAuthProvider }] =
         await Promise.all([import("../config/firebase"), import("firebase/auth")]);
       if (!auth) throw new Error("Firebase no configurado");
+      await initAppCheck();
       if (auth.currentUser?.isAnonymous) {
         await linkWithCredential(auth.currentUser, EmailAuthProvider.credential(email, password));
       } else {
@@ -149,9 +148,10 @@ export const useLazyAuth = (): UseLazyAuthReturn => {
   const signupWithEmail = useCallback(
     async (email: string, password: string) => {
       await initFirebase();
-      const [{ auth }, { createUserWithEmailAndPassword, linkWithCredential, EmailAuthProvider }] =
+      const [{ auth, initAppCheck }, { createUserWithEmailAndPassword, linkWithCredential, EmailAuthProvider }] =
         await Promise.all([import("../config/firebase"), import("firebase/auth")]);
       if (!auth) throw new Error("Firebase no configurado");
+      await initAppCheck();
       if (auth.currentUser?.isAnonymous) {
         await linkWithCredential(auth.currentUser, EmailAuthProvider.credential(email, password));
       } else {


### PR DESCRIPTION
### Motivation
- Reducir peso y blocking en el primer paint siguiendo las recomendaciones de PageSpeed: disminuir el impacto del logo del header y las imágenes de la sección de workouts, y evitar cargar reCAPTCHA (AppCheck) en el bundle inicial.

### Description
- Reemplacé `iconLogo` para el header por `/favicon.svg` en lugar de `pwa-192x192.png` para evitar descargar el asset más pesado en todas las instancias del logo (`src/branding/logoConfig.ts`).
- En `SocialShareSection` se evita renderizar las dos tarjetas laterales en pantallas móviles (<=768px) y ahora solo se renderiza la tarjeta central para reducir descargas y repaints; además añadí `fetchPriority='low'` a las imágenes de previsualización para que no compitan con recursos above-the-fold (`src/components/landing/sections/SocialShareSection.tsx`).
- Cambié la estrategia de inicialización de Firebase AppCheck (reCAPTCHA): se retiró la inicialización en la fase idle del landing y ahora `initAppCheck()` se invoca justo antes de las acciones de autenticación (Google/email/signup) para evitar cargar el script de reCAPTCHA en la carga inicial (`src/hooks/useLazyAuth.ts`).
- Reutilicé las piezas existentes (no se crearon nuevos componentes): se actualizó `logoConfig`, se extendió `SocialShareSection` para detección responsive y se modificó `useLazyAuth` para diferir AppCheck; no se introdujo lógica duplicada.

### Testing
- Ejecuté `pnpm -s build` (producción) y la compilación finalizó correctamente (build OK).
- Levanté el servidor de desarrollo con `pnpm -s dev --host 0.0.0.0 --port 4173` y la página del landing cargó correctamente en viewport móvil.
- Capturé una captura de pantalla del landing móvil con Playwright para validar visualmente que las tarjetas laterales no se cargan en móvil (screenshot generada con éxito).
- No se introdujeron fallos de build ni errores de runtime durante las pruebas automatizadas descritas arriba.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b10d9428a8832fa0499719895f381e)